### PR TITLE
Swagger Changes for Delete Revision of Target and Uninstall

### DIFF
--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
@@ -230,8 +230,8 @@ class RemoveRevision(AAZCommand):
             )
             _builder.set_prop("solutionDependencies", AAZListType, ".solution_dependencies")
             _builder.set_prop("solutionInstanceName", AAZStrType, ".solution_instance_name")
-            _builder.set_prop("solutionTemplate", AAZStrType, ".solution_template", typ_kwargs={"flags": {"required": True}})
-            _builder.set_prop("solutionTemplateVersion", AAZStrType, ".solution_template_version", typ_kwargs={"flags": {"required": True}})
+            _builder.set_prop("solution", AAZStrType, ".solution_template", typ_kwargs={"flags": {"required": True}})
+            _builder.set_prop("solutionVersion", AAZStrType, ".solution_template_version", typ_kwargs={"flags": {"required": True}})
 
             solution_dependencies = _builder.get(".solutionDependencies")
             if solution_dependencies is not None:
@@ -248,8 +248,8 @@ class _RemoveRevisionHelper:
         if _builder is None:
             return
         _builder.set_prop("dependencies", AAZListType, ".dependencies")
-        _builder.set_prop("solutionTemplateId", AAZStrType, ".solution_template_id")
-        _builder.set_prop("solutionTemplateVersion", AAZStrType, ".solution_template_version")
+        _builder.set_prop("solution", AAZStrType, ".solution_template_id")
+        _builder.set_prop("solutionVersion", AAZStrType, ".solution_template_version")
         _builder.set_prop("solutionVersionId", AAZStrType, ".solution_version_id")
         _builder.set_prop("targetId", AAZStrType, ".target_id")
 

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
@@ -60,83 +60,19 @@ class RemoveRevision(AAZCommand):
         # define Arg Group "Body"
 
         _args_schema = cls._args_schema
-        _args_schema.solution_dependencies = AAZListArg(
-            options=["--solution-dependencies"],
+        _args_schema.solution = AAZStrArg(
+            options=["--solution"],
             arg_group="Body",
-            help="Solution Dependencies",
-        )
-        _args_schema.solution_instance_name = AAZStrArg(
-            options=["--solution-instance-name"],
-            arg_group="Body",
-            help="Solution Instance Name",
-            fmt=AAZStrArgFormat(
-                pattern="^(?!v-)(?!.*-v-)[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?)*$",
-                max_length=24,
-            ),
-        )
-        _args_schema.solution_template = AAZStrArg(
-            options=["--solution-template"],
-            arg_group="Body",
-            help="Solution Template Name",
+            help="Solution Name",
             required=True,
         )
-        _args_schema.solution_template_version = AAZStrArg(
-            options=["--solution-template-version"],
+        _args_schema.solution_version = AAZStrArg(
+            options=["--solution-version"],
             arg_group="Body",
-            help="Solution Template Version Name",
+            help="Solution Version Name",
             required=True,
         )
-
-        solution_dependencies = cls._args_schema.solution_dependencies
-        solution_dependencies.Element = AAZObjectArg()
-        cls._build_args_solution_dependency_parameter_create(solution_dependencies.Element)
         return cls._args_schema
-
-    _args_solution_dependency_parameter_create = None
-
-    @classmethod
-    def _build_args_solution_dependency_parameter_create(cls, _schema):
-        if cls._args_solution_dependency_parameter_create is not None:
-            _schema.dependencies = cls._args_solution_dependency_parameter_create.dependencies
-            _schema.solution_template_id = cls._args_solution_dependency_parameter_create.solution_template_id
-            _schema.solution_template_version = cls._args_solution_dependency_parameter_create.solution_template_version
-            _schema.solution_version_id = cls._args_solution_dependency_parameter_create.solution_version_id
-            _schema.target_id = cls._args_solution_dependency_parameter_create.target_id
-            return
-
-        cls._args_solution_dependency_parameter_create = AAZObjectArg()
-
-        solution_dependency_parameter_create = cls._args_solution_dependency_parameter_create
-        solution_dependency_parameter_create.dependencies = AAZListArg(
-            options=["dependencies"],
-            help="Solution dependencies",
-        )
-        solution_dependency_parameter_create.solution_template_id = AAZStrArg(
-            options=["solution-template-id"],
-            help="Solution Template Id",
-        )
-        solution_dependency_parameter_create.solution_template_version = AAZStrArg(
-            options=["solution-template-version"],
-            help="Solution Template Version",
-        )
-        solution_dependency_parameter_create.solution_version_id = AAZStrArg(
-            options=["solution-version-id"],
-            help="Solution Version Id",
-        )
-        solution_dependency_parameter_create.target_id = AAZStrArg(
-            options=["target-id"],
-            help="Target Id",
-        )
-
-        dependencies = cls._args_solution_dependency_parameter_create.dependencies
-        dependencies.Element = AAZObjectArg()
-        cls._build_args_solution_dependency_parameter_create(dependencies.Element)
-
-        _schema.dependencies = cls._args_solution_dependency_parameter_create.dependencies
-        _schema.solution_template_id = cls._args_solution_dependency_parameter_create.solution_template_id
-        _schema.solution_template_version = cls._args_solution_dependency_parameter_create.solution_template_version
-        _schema.solution_version_id = cls._args_solution_dependency_parameter_create.solution_version_id
-        _schema.target_id = cls._args_solution_dependency_parameter_create.target_id
 
     def _execute_operations(self):
         self.pre_operations()
@@ -228,34 +164,14 @@ class RemoveRevision(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
-            _builder.set_prop("solutionDependencies", AAZListType, ".solution_dependencies")
-            _builder.set_prop("solutionInstanceName", AAZStrType, ".solution_instance_name")
-            _builder.set_prop("solution", AAZStrType, ".solution_template", typ_kwargs={"flags": {"required": True}})
-            _builder.set_prop("solutionVersion", AAZStrType, ".solution_template_version", typ_kwargs={"flags": {"required": True}})
-
-            solution_dependencies = _builder.get(".solutionDependencies")
-            if solution_dependencies is not None:
-                _RemoveRevisionHelper._build_schema_solution_dependency_parameter_create(solution_dependencies.set_elements(AAZObjectType, "."))
+            _builder.set_prop("solution", AAZStrType, ".solution", typ_kwargs={"flags": {"required": True}})
+            _builder.set_prop("solutionVersion", AAZStrType, ".solution_version", typ_kwargs={"flags": {"required": True}})
 
             return self.serialize_content(_content_value)
 
 
 class _RemoveRevisionHelper:
     """Helper class for RemoveRevision"""
-
-    @classmethod
-    def _build_schema_solution_dependency_parameter_create(cls, _builder):
-        if _builder is None:
-            return
-        _builder.set_prop("dependencies", AAZListType, ".dependencies")
-        _builder.set_prop("solution", AAZStrType, ".solution_template_id")
-        _builder.set_prop("solutionVersion", AAZStrType, ".solution_template_version")
-        _builder.set_prop("solutionVersionId", AAZStrType, ".solution_version_id")
-        _builder.set_prop("targetId", AAZStrType, ".target_id")
-
-        dependencies = _builder.get(".dependencies")
-        if dependencies is not None:
-            cls._build_schema_solution_dependency_parameter_create(dependencies.set_elements(AAZObjectType, "."))
 
 
 __all__ = ["RemoveRevision"]

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_remove_revision.py
@@ -61,13 +61,13 @@ class RemoveRevision(AAZCommand):
 
         _args_schema = cls._args_schema
         _args_schema.solution = AAZStrArg(
-            options=["--solution"],
+            options=["--solution-template"],
             arg_group="Body",
             help="Solution Name",
             required=True,
         )
         _args_schema.solution_version = AAZStrArg(
-            options=["--solution-version"],
+            options=["--solution-template-version"],
             arg_group="Body",
             help="Solution Version Name",
             required=True,

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
@@ -60,20 +60,17 @@ class Uninstall(AAZCommand):
         # define Arg Group "Body"
 
         _args_schema = cls._args_schema
+        _args_schema.solution_instance_name = AAZStrArg(
+            options=["--solution-instance-name"],
+            arg_group="Body",
+            help="Solution Instance Name",
+        )
         _args_schema.solution_name = AAZStrArg(
             options=["--solution-name"],
             arg_group="Body",
             help="Solution Name",
             required=True,
         )
-
-        _args_schema.solution_instance_name = AAZStrArg(
-            options=["--solution-instance-name"],
-            arg_group="Body",
-            help="solution Instance Name",
-            required=False,
-        )
-        
         return cls._args_schema
 
     def _execute_operations(self):
@@ -166,8 +163,8 @@ class Uninstall(AAZCommand):
                 typ=AAZObjectType,
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
+            _builder.set_prop("solutionInstanceName", AAZStrType, ".solution_instance_name")
             _builder.set_prop("solutionName", AAZStrType, ".solution_name", typ_kwargs={"flags": {"required": True}})
-            _builder.set_prop("solutionInstanceName", AAZStrType, ".solution_instance_name", typ_kwargs={"flags": {"required": False}})
 
             return self.serialize_content(_content_value)
 

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
@@ -66,6 +66,14 @@ class Uninstall(AAZCommand):
             help="Solution Name",
             required=True,
         )
+
+        _args_schema.solution_instance_name = AAZStrArg(
+            options=["--solution-instance-name"],
+            arg_group="Body",
+            help="solution Instance Name",
+            required=False,
+        )
+        
         return cls._args_schema
 
     def _execute_operations(self):
@@ -159,6 +167,7 @@ class Uninstall(AAZCommand):
                 typ_kwargs={"flags": {"required": True, "client_flatten": True}}
             )
             _builder.set_prop("solutionName", AAZStrType, ".solution_name", typ_kwargs={"flags": {"required": True}})
+            _builder.set_prop("solutionInstanceName", AAZStrType, ".solution_instance_name", typ_kwargs={"flags": {"required": False}})
 
             return self.serialize_content(_content_value)
 

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/target/_uninstall.py
@@ -61,12 +61,12 @@ class Uninstall(AAZCommand):
 
         _args_schema = cls._args_schema
         _args_schema.solution_instance_name = AAZStrArg(
-            options=["--solution-instance-name"],
+            options=["--solution-instance"],
             arg_group="Body",
             help="Solution Instance Name",
         )
         _args_schema.solution_name = AAZStrArg(
-            options=["--solution-name"],
+            options=["--solution-template"],
             arg_group="Body",
             help="Solution Name",
             required=True,


### PR DESCRIPTION
```powershell




az workload-orchestration target uninstall --help
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\UNKNOWN.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\workload_operations.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\UNKNOWN.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\workload_operations.egg-info
This command is from the following extension: workload-orchestration

Command
    az workload-orchestration target uninstall : Post request to uninstall.
Arguments
    --no-wait                      : Do not wait for the long-running operation to finish.  Allowed
                                     values: 0, 1, f, false, n, no, t, true, y, yes.

Body Arguments
    --solution-template [Required] : Solution Name.
    --solution-instance            : Solution Instance Name.

Resource Id Arguments
    --ids                          : One or more resource IDs (space-delimited). It should be a
                                     complete resource ID containing all information of 'Resource
                                     Id' arguments. You should provide either --ids or other
                                     'Resource Id' arguments.
    --resource-group -g            : Name of resource group. You can configure the default group
                                     using `az configure --defaults group=<name>`.
    --subscription                 : Name or ID of subscription. You can configure the default
                                     subscription using `az account set -s NAME_OR_ID`.
    --target-name                  : Name of the target.

Global Arguments
    --debug                        : Increase logging verbosity to show all debug logs.
    --help -h                      : Show this help message and exit.
    --only-show-errors             : Only show errors, suppressing warnings.
    --output -o                    : Output format.  Allowed values: json, jsonc, none, table, tsv,
                                     yaml, yamlc.  Default: json.
    --query                        : JMESPath query string. See http://jmespath.org/ for more
                                     information and examples.
    --verbose                      : Increase logging verbosity. Use --debug for full debug logs.

To search AI knowledge base for examples, use: az find "az workload-orchestration target uninstall"

You have 2 update(s) available. Consider updating your CLI installation with 'az upgrade'

az workload-orchestration target remove-revision --help
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\UNKNOWN.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\workload_operations.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\UNKNOWN.egg-info
D:\a\_work\1\s\build_scripts\windows\artifacts\cli\Lib\site-packages\pkginfo/develop.py:46: UserWarning: No PKG-INFO found for path: C:\Users\audapure\Repo\Projects\CLI\azure-cli-extensions\src\workload-orchestration\workload_operations.egg-info
This command is from the following extension: workload-orchestration

Command
    az workload-orchestration target remove-revision : Post request to remove solution version
    revision.
Arguments
    --no-wait                              : Do not wait for the long-running operation to finish.
                                             Allowed values: 0, 1, f, false, n, no, t, true, y, yes.

Body Arguments
    --solution-template         [Required] : Solution Name.
    --solution-template-version [Required] : Solution Version Name.

Resource Id Arguments
    --ids                                  : One or more resource IDs (space-delimited). It should
                                             be a complete resource ID containing all information of
                                             'Resource Id' arguments. You should provide either
                                             --ids or other 'Resource Id' arguments.
    --resource-group -g                    : Name of resource group. You can configure the default
                                             group using `az configure --defaults group=<name>`.
    --subscription                         : Name or ID of subscription. You can configure the
                                             default subscription using `az account set -s
                                             NAME_OR_ID`.
    --target-name                          : Name of the target.

Global Arguments
    --debug                                : Increase logging verbosity to show all debug logs.
    --help -h                              : Show this help message and exit.
    --only-show-errors                     : Only show errors, suppressing warnings.
    --output -o                            : Output format.  Allowed values: json, jsonc, none,
                                             table, tsv, yaml, yamlc.  Default: json.
    --query                                : JMESPath query string. See http://jmespath.org/ for
                                             more information and examples.
    --verbose                              : Increase logging verbosity. Use --debug for full debug
                                             logs.

To search AI knowledge base for examples, use: az find "az workload-orchestration target remove-
revision"

```
