### PR TITLE
Add support for passing name in metadata Yaml file

### DIFF
--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
@@ -176,10 +176,10 @@ class Create(AAZCommand):
                 raise ValidationError("Invalid YAML passed")
             
             if configTemplateName == "Undefined" and configTemplateValue.get("metadata", {}).get("name") is None:
-                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+                raise ValidationError("No name input detected. One of following input is required: \n1. Name in command argument\n2. Name in file under metadata")
             
             if configTemplateName != "Undefined" and configTemplateValue.get("metadata", {}).get("name") is not None and configTemplateName != configTemplateValue['metadata']['name']:
-                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+                raise ValidationError("Config Template name passed as argument and name in file under metadata have different values.")
             
             if configTemplateName == "Undefined":    
                 configTemplateName = configTemplateValue['metadata']['name']
@@ -378,10 +378,10 @@ class Create(AAZCommand):
                 raise ValidationError("Invalid YAML passed")
             
             if configTemplateName == "Undefined" and configTemplateValue.get("metadata", {}).get("name") is None:
-                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+                raise ValidationError("No name input detected. One of following input is required: \n1. Name in command argument\n2. Name in file under metadata")
             
             if configTemplateName != "Undefined" and configTemplateValue.get("metadata", {}).get("name") is not None and configTemplateName != configTemplateValue['metadata']['name']:
-                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+                raise ValidationError("Config Template name passed as argument and name in file under metadata have different values.")
             
             if configTemplateName == "Undefined":    
                 configTemplateName = configTemplateValue['metadata']['name']

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
@@ -9,7 +9,8 @@
 # flake8: noqa
 
 from azure.cli.core.aaz import *
-
+from azure.cli.core.azclierror import ValidationError
+import yaml
 
 @register_command(
     "workload-orchestration config-template create",
@@ -45,7 +46,7 @@ class Create(AAZCommand):
         _args_schema.config_template_name = AAZStrArg(
             options=["-n", "--name", "--config-template-name"],
             help="The name of the ConfigTemplate",
-            required=True,
+            required=False,
             fmt=AAZStrArgFormat(
                 pattern="^[a-zA-Z0-9-]{3,24}$",
             ),
@@ -149,7 +150,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/configTemplates/{configTemplateName}",
                 **self.url_parameters
             )
 
@@ -163,9 +164,29 @@ class Create(AAZCommand):
 
         @property
         def url_parameters(self):
+            configTemplateName = str(self.ctx.args.config_template_name)
+            configTemplateValue = object()
+
+            try:
+                configTemplateValue = yaml.safe_load(str(self.ctx.args.configurations))
+            except Exception as e:
+                raise ValidationError("Invalid YAML passed or error in parsing yaml")
+            
+            if type(configTemplateValue) == "string":
+                raise ValidationError("Invalid YAML passed")
+            
+            if configTemplateName == "Undefined" and configTemplateValue.get("metadata", {}).get("name") is None:
+                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+            
+            if configTemplateName != "Undefined" and configTemplateValue.get("metadata", {}).get("name") is not None and configTemplateName != configTemplateValue['metadata']['name']:
+                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+            
+            if configTemplateName == "Undefined":    
+                configTemplateName = configTemplateValue['metadata']['name']
+            
             parameters = {
                 **self.serialize_url_param(
-                    "configTemplateName", self.ctx.args.config_template_name,
+                    "configTemplateName", configTemplateName,
                     required=True,
                 ),
                 **self.serialize_url_param(
@@ -331,7 +352,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}/createVersion",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/configTemplates/{configTemplateName}/createVersion",
                 **self.url_parameters
             )
 
@@ -345,9 +366,29 @@ class Create(AAZCommand):
 
         @property
         def url_parameters(self):
+            configTemplateName = str(self.ctx.args.config_template_name)
+            configTemplateValue = object()
+
+            try:
+                configTemplateValue = yaml.safe_load(str(self.ctx.args.configurations))
+            except Exception as e:
+                raise ValidationError("Invalid YAML passed or error in parsing yaml")
+            
+            if type(configTemplateValue) == "string":
+                raise ValidationError("Invalid YAML passed")
+            
+            if configTemplateName == "Undefined" and configTemplateValue.get("metadata", {}).get("name") is None:
+                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+            
+            if configTemplateName != "Undefined" and configTemplateValue.get("metadata", {}).get("name") is not None and configTemplateName != configTemplateValue['metadata']['name']:
+                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+            
+            if configTemplateName == "Undefined":    
+                configTemplateName = configTemplateValue['metadata']['name']
+            
             parameters = {
                 **self.serialize_url_param(
-                    "configTemplateName", self.ctx.args.config_template_name,
+                    "configTemplateName", configTemplateName,
                     required=True,
                 ),
                 **self.serialize_url_param(

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/config_template/_create.py
@@ -150,7 +150,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/configTemplates/{configTemplateName}",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}",
                 **self.url_parameters
             )
 
@@ -352,7 +352,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/configTemplates/{configTemplateName}/createVersion",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/configTemplates/{configTemplateName}/createVersion",
                 **self.url_parameters
             )
 

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
@@ -169,10 +169,10 @@ class Create(AAZCommand):
                 raise ValidationError("Invalid YAML passed")
             
             if schemaName == "Undefined" and schemaValue.get("metadata", {}).get("name") is None:
-                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+                raise ValidationError("No name input detected. One of following input is required: \n1. Name in command argument\n2. Name in file under metadata")
             
             if schemaName != "Undefined" and schemaValue.get("metadata", {}).get("name") is not None and schemaName != schemaValue['metadata']['name']:
-                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+                raise ValidationError("Schema name passed as argument and name in file under metadata has different values")
             
             if schemaName == "Undefined":    
                 schemaName = schemaValue['metadata']['name']
@@ -375,10 +375,10 @@ class Create(AAZCommand):
                 raise ValidationError("Invalid YAML passed")
             
             if schemaName == "Undefined" and schemaValue.get("metadata", {}).get("name") is None:
-                raise ValidationError("Schema name needs to be passed either as option in --schema-name or in schema yaml in the metadata")
+                raise ValidationError("No name input detected. One of following input is required: \n1. Name in command argument\n2. Name in file under metadata")
             
             if schemaName != "Undefined" and schemaValue.get("metadata", {}).get("name") is not None and schemaName != schemaValue['metadata']['name']:
-                raise ValidationError("Schema name passed as argument and name passed in schema yaml have different values")
+                raise ValidationError("Schema name passed as argument and name in file under metadata has different values")
             
             if schemaName == "Undefined":    
                 schemaName = schemaValue['metadata']['name']

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
@@ -144,7 +144,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/schemas/{schemaName}",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}",
                 **self.url_parameters
             )
 
@@ -349,7 +349,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/schemas/{schemaName}/createVersion",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/createVersion",
                 **self.url_parameters
             )
 

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/schema/_create.py
@@ -9,7 +9,8 @@
 # flake8: noqa
 
 from azure.cli.core.aaz import *
-
+from azure.cli.core.azclierror import ValidationError
+import yaml
 
 @register_command(
     "workload-orchestration schema create",
@@ -48,7 +49,7 @@ class Create(AAZCommand):
         _args_schema.schema_name = AAZStrArg(
             options=["-n", "--name", "--schema-name"],
             help="The name of the Schema",
-            required=True,
+            required=False,
             fmt=AAZStrArgFormat(
                 pattern="^[a-zA-Z0-9-]{3,24}$",
             ),
@@ -143,7 +144,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/schemas/{schemaName}",
                 **self.url_parameters
             )
 
@@ -157,13 +158,32 @@ class Create(AAZCommand):
 
         @property
         def url_parameters(self):
+            schemaName = str(self.ctx.args.schema_name)
+            schemaValue = object()
+            try:
+                schemaValue = yaml.safe_load(str(self.ctx.args.value))
+            except Exception as e:
+                raise ValidationError("Invalid YAML passed or error in parsing yaml")
+            
+            if type(schemaValue) == "string":
+                raise ValidationError("Invalid YAML passed")
+            
+            if schemaName == "Undefined" and schemaValue.get("metadata", {}).get("name") is None:
+                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+            
+            if schemaName != "Undefined" and schemaValue.get("metadata", {}).get("name") is not None and schemaName != schemaValue['metadata']['name']:
+                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+            
+            if schemaName == "Undefined":    
+                schemaName = schemaValue['metadata']['name']
+            
             parameters = {
                 **self.serialize_url_param(
                     "resourceGroupName", self.ctx.args.resource_group,
                     required=True,
                 ),
                 **self.serialize_url_param(
-                    "schemaName", self.ctx.args.schema_name,
+                    "schemaName", schemaName,
                     required=True,
                 ),
                 **self.serialize_url_param(
@@ -221,7 +241,7 @@ class Create(AAZCommand):
             tags = _builder.get(".tags")
             if tags is not None:
                 tags.set_elements(AAZStrType, ".")
-
+            
             return self.serialize_content(_content_value)
 
         def on_200_201(self, session):
@@ -329,7 +349,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/schemas/{schemaName}/createVersion",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/schemas/{schemaName}/createVersion",
                 **self.url_parameters
             )
 
@@ -343,13 +363,33 @@ class Create(AAZCommand):
 
         @property
         def url_parameters(self):
+            schemaName = str(self.ctx.args.schema_name)
+            schemaValue = object()
+            
+            try:
+                schemaValue = yaml.safe_load(str(self.ctx.args.value))
+            except Exception as e:
+                raise ValidationError("Invalid YAML passed or error in parsing yaml")
+            
+            if type(schemaValue) == "string":
+                raise ValidationError("Invalid YAML passed")
+            
+            if schemaName == "Undefined" and schemaValue.get("metadata", {}).get("name") is None:
+                raise ValidationError("Schema name needs to be passed either as option in --schema-name or in schema yaml in the metadata")
+            
+            if schemaName != "Undefined" and schemaValue.get("metadata", {}).get("name") is not None and schemaName != schemaValue['metadata']['name']:
+                raise ValidationError("Schema name passed as argument and name passed in schema yaml have different values")
+            
+            if schemaName == "Undefined":    
+                schemaName = schemaValue['metadata']['name']
+            
             parameters = {
                 **self.serialize_url_param(
                     "resourceGroupName", self.ctx.args.resource_group,
                     required=True,
                 ),
                 **self.serialize_url_param(
-                    "schemaName", self.ctx.args.schema_name,
+                    "schemaName", schemaName,
                     required=True,
                 ),
                 **self.serialize_url_param(
@@ -399,7 +439,7 @@ class Create(AAZCommand):
             properties = _builder.get(".schemaVersion.properties")
             if properties is not None:
                 properties.set_prop("value", AAZStrType, ".value", typ_kwargs={"flags": {"required": True}})
-
+            
             return self.serialize_content(_content_value)
 
         def on_200(self, session):

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_create.py
@@ -199,10 +199,10 @@ class Create(AAZCommand):
                 raise ValidationError("Invalid YAML passed")
             
             if solutionTemplateName == "Undefined" and solutionTemplateValue.get("metadata", {}).get("name") is None:
-                raise ValidationError("Schema name needs to be passed either as argument in --schema-name or in schema yaml in the metadata")
+                raise ValidationError("No name input detected. One of following input is required: \n1. Name in command argument\n2. Name in file under metadata")
             
             if solutionTemplateName != "Undefined" and solutionTemplateValue.get("metadata", {}).get("name") is not None and solutionTemplateName != solutionTemplateValue['metadata']['name']:
-                raise ValidationError("Schema name passed as argument and name passed in schema yaml has different values")
+                raise ValidationError("Solution template name passed as argument and name in file under metadata have different values")
             
             if solutionTemplateName == "Undefined":    
                 solutionTemplateName = solutionTemplateValue['metadata']['name']

--- a/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_create.py
+++ b/src/workload-orchestration/azext_workload_orchestration/aaz/latest/workload_orchestration/solution_template/_create.py
@@ -173,7 +173,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/solutionTemplates/{solutionTemplateName}",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}",
                 **self.url_parameters
             )
 
@@ -391,7 +391,7 @@ class Create(AAZCommand):
         @property
         def url(self):
             return self.client.format_url(
-                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Private.Edge/solutionTemplates/{solutionTemplateName}/createVersion",
+                "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Edge/solutionTemplates/{solutionTemplateName}/createVersion",
                 **self.url_parameters
             )
 


### PR DESCRIPTION
Add support in schema, solution-template and config-template creation for passing the name in metadata Yaml file for via optional argument CLI argument.

This checklist is used to make sure that common guidelines for a pull request are followed.

### Related command
<!--- Please provide the related command with az {command} if you can, so that we can quickly route to the related person to review. --->



### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally? (`pip install wheel==0.30.0` required)
- [ ] My extension version conforms to the [Extension version schema](https://github.com/Azure/azure-cli/blob/release/doc/extensions/versioning_guidelines.md)

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your pull request is merged into main branch, a new pull request will be created to update `src/index.json` automatically.  
You only need to update the version information in file setup.py and historical information in file HISTORY.rst in your PR but do not modify `src/index.json`. 
